### PR TITLE
puavo-ltsp: Depend on puavo-rest-bootserver

### DIFF
--- a/packages/puavo-ltsp/debian/control
+++ b/packages/puavo-ltsp/debian/control
@@ -16,7 +16,7 @@ Depends: ${misc:Depends}, libsasl2-modules-gssapi-mit, isc-dhcp-server, bind9,
  shorewall, linux-image-server, nfs-kernel-server, sssd, qemu-kvm,
  libvirt-bin, ruby-ipaddress, syslinux, ruby-highline, ruby-dnsruby,
  openbsd-inetd, samba, cifs-utils, ipsec-tools, racoon, puavo-sharedir-manager,
- puavo-logrelay, nginx, puavo-rest, ntp
+ puavo-logrelay, nginx, puavo-rest-bootserver, ntp
 Recommends: tshark, git, emacs23-nox, sysstat, tmux, vim, openvpn, puavo-wlangw,
  etherwake, nmap, fping
 Conflicts: avahi-daemon, ltsp-server, nscd, tftpd-hpa


### PR DESCRIPTION
instead of puavo-rest directly
